### PR TITLE
ci: add a TS ci for test build and lint

### DIFF
--- a/.github/workflows/ts-ci.yaml
+++ b/.github/workflows/ts-ci.yaml
@@ -1,0 +1,34 @@
+name: CI Workflow Frontend (TypeScript)
+
+on:
+  push:
+    paths: 
+      - web/**
+  pull_request:
+    paths: 
+      - web/**
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./web
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Check Linting
+        run: npm run lint
+
+      - name: Build Frontend
+        run: npm run build


### PR DESCRIPTION
### Issue

Closes #39 

### Changes Proposed

Add a CI run on Pull Requests to check for build and Linting for incoming TypeScript code.