### PR TITLE
fix: Update work dir in go ci

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./server
+        working-directory: ./rate_shield
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Update the correct working dir for Go CI

![Screenshot 2024-10-26 at 11 01 19 PM](https://github.com/user-attachments/assets/40b65ad1-c95c-4e5b-8005-af206e520979)
