### PR TITLE
feat: implement in-memory fallback for Redis failures (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,15 @@ Why not? With some free time on hand, RateShield was created to explore the pote
 
 - **Customizable Limiting:** <br>
    Tailor rate limiting rules to each API endpoint according to your needs.
-   
+
 - **Intuitive Dashboard:** <br>
    A user-friendly interface to monitor and manage all your rate limits effectively.
-   
+
 - **Easy Integration:** <br>
    Plug-and-play middleware that seamlessly integrates into your existing infrastructure.
+
+- **Redis Fallback (Optional):** <br>
+   Automatic in-memory fallback when Redis is unavailable, ensuring continuous operation even during Redis outages.
 
 ---
 
@@ -49,8 +52,11 @@ Why not? With some free time on hand, RateShield was created to explore the pote
 
 ---
 
-#### 🪧 Usage Guide
-  Check out this [document](https://github.com/x-sushant-x/Rate-Shield/tree/main/rate_shield/documentation).
+#### 🪧 Documentation
+
+- **Usage Guide**: Check out this [document](https://github.com/x-sushant-x/Rate-Shield/tree/main/rate_shield/documentation)
+- **Setup Guide**: See [SETUP.md](./SETUP.md) for installation and configuration
+- **Redis Fallback**: Learn about the [in-memory fallback feature](./REDIS_FALLBACK.md) for Redis resilience
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -2,8 +2,8 @@
 
 #### Prerequisite
 * Docker
-* Redis Instance (for rules)
-* Redis Cluster (with ReJSON Module Enabled)
+* Redis Instance (for rules) - Optional if fallback is enabled
+* Redis Cluster (with ReJSON Module Enabled) - Optional if fallback is enabled
 
 * Environment variables for the application:
     * RATE_SHIELD_PORT: The port number the application will listen on.
@@ -13,6 +13,8 @@
     * REDIS_CLUSTERS_URLS: Comma seperated urls. Ex - 127.0.0.1:6380,127.0.0.1:6381
     * REDIS_CLUSTER_USERNAME: Username for Redis Cluster authentication.
     * REDIS_CLUSTER_PASSWORD: Password for Redis Cluster authentication.
+    * **ENABLE_REDIS_FALLBACK** (Optional): Enable in-memory fallback when Redis is unavailable (true/false, default: false)
+    * **REDIS_RETRY_INTERVAL** (Optional): Interval for retrying Redis connection when using fallback (default: 30s, format: 30s, 1m, 5m, etc.)
 
 
 <br>
@@ -21,6 +23,8 @@
 2. Build docker image using `docker build -t rate-shield-backend .`
 
 3. Once docker image is built you can run it using below command.
+
+**Standard setup (with Redis):**
 ```
 docker run -d \
   -p 8080:8080 \
@@ -28,7 +32,21 @@ docker run -d \
   -e REDIS_RULES_INSTANCE_URL=redis://localhost:6379 \
   -e REDIS_RULES_INSTANCE_USERNAME=user \
   -e REDIS_RULES_INSTANCE_PASSWORD=password \
-  -e REDIS_CLUSTERS_URLS=localhost:6380,localhost:6381
+  -e REDIS_CLUSTERS_URLS=localhost:6380,localhost:6381 \
+  rate-shield-app
+```
+
+**With Redis fallback enabled:**
+```
+docker run -d \
+  -p 8080:8080 \
+  -e RATE_SHIELD_PORT=8080 \
+  -e REDIS_RULES_INSTANCE_URL=redis://localhost:6379 \
+  -e REDIS_RULES_INSTANCE_USERNAME=user \
+  -e REDIS_RULES_INSTANCE_PASSWORD=password \
+  -e REDIS_CLUSTERS_URLS=localhost:6380,localhost:6381 \
+  -e ENABLE_REDIS_FALLBACK=true \
+  -e REDIS_RETRY_INTERVAL=30s \
   rate-shield-app
 ```
 
@@ -52,3 +70,39 @@ rate_shield_frontend
 ```
 
 <b>Important: -</b> VITE_RATE_SHIELD_BACKEND_BASE_URL should have the URL of your backend docker container and -p and -e PORT value should match.
+
+<br>
+
+---
+
+### 🔄 Redis Fallback Feature
+
+Rate Shield now supports **automatic in-memory fallback** when Redis is unavailable. This feature is optional and disabled by default.
+
+#### When to use fallback?
+
+- ✅ **Development/Testing**: Work without Redis dependency
+- ✅ **Temporary Resilience**: Handle short Redis outages gracefully
+- ✅ **Single Instance Deployments**: When running one Rate Shield instance
+
+#### When NOT to use fallback?
+
+- ❌ **Production Multi-Instance**: Multiple Rate Shield instances (data won't sync)
+- ❌ **Strict Rate Limits**: When precise distributed rate limiting is critical
+- ❌ **Long-Term Operation**: Extended periods without Redis
+
+#### Quick Start
+
+1. Set environment variables:
+   ```bash
+   ENABLE_REDIS_FALLBACK=true
+   REDIS_RETRY_INTERVAL=30s  # Optional, default is 30s
+   ```
+
+2. Application will:
+   - Start successfully even if Redis is down
+   - Use in-memory storage for rate limiting
+   - Automatically restore Redis when available
+   - Log warnings during fallback mode
+
+**📖 For complete documentation, limitations, and best practices, see [REDIS_FALLBACK.md](../REDIS_FALLBACK.md)**

--- a/rate_shield/api/server.go
+++ b/rate_shield/api/server.go
@@ -65,7 +65,7 @@ func (s Server) setupCORS(h http.Handler) http.Handler {
 }
 
 func (s Server) rulesRoutes(mux *http.ServeMux) {
-	redisRuleClient, err := redisClient.NewRulesClient()
+	redisRuleClient, _, err := redisClient.NewRulesClient()
 	if err != nil {
 		log.Err(err).Msg("unable to setup new redis rules client")
 		log.Fatal()

--- a/rate_shield/documentation/README.md
+++ b/rate_shield/documentation/README.md
@@ -94,3 +94,40 @@ To streamline the rate limiting process, you can create custom middleware or int
 2. Receive the response and handle it accordingly, such as allowing the request to proceed or returning an error message to the client.
 
 While I'm not providing specific code examples for creating middleware in different languages and frameworks, we encourage you to implement it in your environment of choice. Your contributions are valuable; feel free to share your custom middleware implementations with the community to enhance the Rate Shield project.
+
+---
+
+## Redis Fallback Feature
+
+Rate Shield includes an **optional in-memory fallback** mechanism that activates when Redis becomes unavailable.
+
+### Configuration
+
+Enable fallback mode by setting these environment variables:
+
+```bash
+ENABLE_REDIS_FALLBACK=true       # Enable fallback (default: false)
+REDIS_RETRY_INTERVAL=30s         # Health check interval (default: 30s)
+```
+
+### How It Works
+
+1. **Redis Available**: Normal operation using Redis for rate limiting
+2. **Redis Fails**: Automatically switches to in-memory storage
+3. **Periodic Health Checks**: Monitors Redis availability based on retry interval
+4. **Auto-Recovery**: Switches back to Redis when connection is restored
+
+### Important Notes
+
+⚠️ **Limitations:**
+- In-memory data is **per-instance** (not distributed across multiple Rate Shield instances)
+- Data is **lost on restart** (non-persistent)
+- Best for **development**, **testing**, or **temporary resilience**
+- **Not recommended** for production multi-instance deployments
+
+✅ **Best For:**
+- Development without Redis dependency
+- Handling temporary Redis outages
+- Single-instance deployments
+
+📖 **Full Documentation**: See [REDIS_FALLBACK.md](../../REDIS_FALLBACK.md) for complete details, logging behavior, and best practices.

--- a/rate_shield/fallback/client_wrapper.go
+++ b/rate_shield/fallback/client_wrapper.go
@@ -1,0 +1,286 @@
+package fallback
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	redisClient "github.com/x-sushant-x/RateShield/redis"
+)
+
+// FallbackRateLimitClient wraps Redis client with in-memory fallback
+type FallbackRateLimitClient struct {
+	redisClient      redisClient.RedisRateLimiterClient
+	memoryStore      *InMemoryRateLimitStore
+	isRedisAvailable bool
+	mutex            sync.RWMutex
+	lastWarningTime  time.Time
+	warningInterval  time.Duration
+}
+
+// NewFallbackRateLimitClient creates a new fallback client
+func NewFallbackRateLimitClient(redisClient redisClient.RedisRateLimiterClient, memoryStore *InMemoryRateLimitStore) *FallbackRateLimitClient {
+	return &FallbackRateLimitClient{
+		redisClient:      redisClient,
+		memoryStore:      memoryStore,
+		isRedisAvailable: true,
+		warningInterval:  5 * time.Minute,
+		lastWarningTime:  time.Now(),
+	}
+}
+
+// JSONSet stores a value as JSON
+func (f *FallbackRateLimitClient) JSONSet(key string, val interface{}) error {
+	f.mutex.RLock()
+	isAvailable := f.isRedisAvailable
+	f.mutex.RUnlock()
+
+	if isAvailable {
+		err := f.redisClient.JSONSet(key, val)
+		if err != nil {
+			f.switchToFallback()
+			return f.memoryStore.JSONSet(key, val)
+		}
+		return nil
+	}
+
+	f.logFallbackWarning()
+	return f.memoryStore.JSONSet(key, val)
+}
+
+// JSONGet retrieves a value as JSON string
+func (f *FallbackRateLimitClient) JSONGet(key string) (string, bool, error) {
+	f.mutex.RLock()
+	isAvailable := f.isRedisAvailable
+	f.mutex.RUnlock()
+
+	if isAvailable {
+		result, found, err := f.redisClient.JSONGet(key)
+		if err != nil {
+			f.switchToFallback()
+			return f.memoryStore.JSONGet(key)
+		}
+		return result, found, nil
+	}
+
+	f.logFallbackWarning()
+	return f.memoryStore.JSONGet(key)
+}
+
+// Expire sets an expiration time on a key
+func (f *FallbackRateLimitClient) Expire(key string, expiration time.Duration) error {
+	f.mutex.RLock()
+	isAvailable := f.isRedisAvailable
+	f.mutex.RUnlock()
+
+	if isAvailable {
+		err := f.redisClient.Expire(key, expiration)
+		if err != nil {
+			f.switchToFallback()
+			return f.memoryStore.Expire(key, expiration)
+		}
+		return nil
+	}
+
+	f.logFallbackWarning()
+	return f.memoryStore.Expire(key, expiration)
+}
+
+// Delete removes a key
+func (f *FallbackRateLimitClient) Delete(key string) error {
+	f.mutex.RLock()
+	isAvailable := f.isRedisAvailable
+	f.mutex.RUnlock()
+
+	if isAvailable {
+		err := f.redisClient.Delete(key)
+		if err != nil {
+			f.switchToFallback()
+			return f.memoryStore.Delete(key)
+		}
+		return nil
+	}
+
+	f.logFallbackWarning()
+	return f.memoryStore.Delete(key)
+}
+
+// switchToFallback marks Redis as unavailable and logs a warning
+func (f *FallbackRateLimitClient) switchToFallback() {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if f.isRedisAvailable {
+		f.isRedisAvailable = false
+		log.Warn().Msg("Redis unavailable, switching to in-memory fallback for rate limiting")
+	}
+}
+
+// RestoreRedis marks Redis as available again
+func (f *FallbackRateLimitClient) RestoreRedis() {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if !f.isRedisAvailable {
+		f.isRedisAvailable = true
+		log.Info().Msg("Redis connection restored, switching back from in-memory fallback")
+	}
+}
+
+// IsRedisAvailable returns the current Redis availability status
+func (f *FallbackRateLimitClient) IsRedisAvailable() bool {
+	f.mutex.RLock()
+	defer f.mutex.RUnlock()
+	return f.isRedisAvailable
+}
+
+// logFallbackWarning logs a warning periodically when using fallback
+func (f *FallbackRateLimitClient) logFallbackWarning() {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	now := time.Now()
+	if now.Sub(f.lastWarningTime) >= f.warningInterval {
+		log.Warn().Msg("Rate limiting using in-memory fallback (Redis still unavailable)")
+		f.lastWarningTime = now
+	}
+}
+
+// FallbackSlidingWindowClient wraps sliding window operations with fallback
+type FallbackSlidingWindowClient struct {
+	redisClient      redisClient.SlidingWindowClient
+	memoryStore      *InMemorySlidingWindowStore
+	isRedisAvailable bool
+	mutex            sync.RWMutex
+	lastWarningTime  time.Time
+	warningInterval  time.Duration
+}
+
+// NewFallbackSlidingWindowClient creates a new fallback sliding window client
+func NewFallbackSlidingWindowClient(redisClient redisClient.SlidingWindowClient, memoryStore *InMemorySlidingWindowStore) *FallbackSlidingWindowClient {
+	return &FallbackSlidingWindowClient{
+		redisClient:      redisClient,
+		memoryStore:      memoryStore,
+		isRedisAvailable: true,
+		warningInterval:  5 * time.Minute,
+		lastWarningTime:  time.Now(),
+	}
+}
+
+// ZRemRangeByScore removes entries with scores between min and max
+func (f *FallbackSlidingWindowClient) ZRemRangeByScore(ctx context.Context, key, min, max string) error {
+	f.mutex.RLock()
+	isAvailable := f.isRedisAvailable
+	f.mutex.RUnlock()
+
+	if isAvailable {
+		err := f.redisClient.ZRemRangeByScore(ctx, key, min, max)
+		if err != nil {
+			f.switchToFallback()
+			return f.memoryStore.ZRemRangeByScore(ctx, key, min, max)
+		}
+		return nil
+	}
+
+	f.logFallbackWarning()
+	return f.memoryStore.ZRemRangeByScore(ctx, key, min, max)
+}
+
+// ZCount counts entries with scores between min and max
+func (f *FallbackSlidingWindowClient) ZCount(ctx context.Context, key, min, max string) (int64, error) {
+	f.mutex.RLock()
+	isAvailable := f.isRedisAvailable
+	f.mutex.RUnlock()
+
+	if isAvailable {
+		count, err := f.redisClient.ZCount(ctx, key, min, max)
+		if err != nil {
+			f.switchToFallback()
+			return f.memoryStore.ZCount(ctx, key, min, max)
+		}
+		return count, nil
+	}
+
+	f.logFallbackWarning()
+	return f.memoryStore.ZCount(ctx, key, min, max)
+}
+
+// ZAdd adds an entry with the given score
+func (f *FallbackSlidingWindowClient) ZAdd(ctx context.Context, key string, timestamp int64) error {
+	f.mutex.RLock()
+	isAvailable := f.isRedisAvailable
+	f.mutex.RUnlock()
+
+	if isAvailable {
+		err := f.redisClient.ZAdd(ctx, key, timestamp)
+		if err != nil {
+			f.switchToFallback()
+			return f.memoryStore.ZAdd(ctx, key, timestamp)
+		}
+		return nil
+	}
+
+	f.logFallbackWarning()
+	return f.memoryStore.ZAdd(ctx, key, timestamp)
+}
+
+// Expire sets expiration time on a key
+func (f *FallbackSlidingWindowClient) Expire(ctx context.Context, key string, expiration time.Duration) error {
+	f.mutex.RLock()
+	isAvailable := f.isRedisAvailable
+	f.mutex.RUnlock()
+
+	if isAvailable {
+		err := f.redisClient.Expire(ctx, key, expiration)
+		if err != nil {
+			f.switchToFallback()
+			return f.memoryStore.Expire(ctx, key, expiration)
+		}
+		return nil
+	}
+
+	f.logFallbackWarning()
+	return f.memoryStore.Expire(ctx, key, expiration)
+}
+
+// switchToFallback marks Redis as unavailable
+func (f *FallbackSlidingWindowClient) switchToFallback() {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if f.isRedisAvailable {
+		f.isRedisAvailable = false
+		log.Warn().Msg("Redis unavailable, switching to in-memory fallback for sliding window rate limiting")
+	}
+}
+
+// RestoreRedis marks Redis as available again
+func (f *FallbackSlidingWindowClient) RestoreRedis() {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if !f.isRedisAvailable {
+		f.isRedisAvailable = true
+		log.Info().Msg("Redis connection restored for sliding window, switching back from in-memory fallback")
+	}
+}
+
+// IsRedisAvailable returns the current Redis availability status
+func (f *FallbackSlidingWindowClient) IsRedisAvailable() bool {
+	f.mutex.RLock()
+	defer f.mutex.RUnlock()
+	return f.isRedisAvailable
+}
+
+// logFallbackWarning logs a warning periodically
+func (f *FallbackSlidingWindowClient) logFallbackWarning() {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	now := time.Now()
+	if now.Sub(f.lastWarningTime) >= f.warningInterval {
+		log.Warn().Msg("Sliding window rate limiting using in-memory fallback (Redis still unavailable)")
+		f.lastWarningTime = now
+	}
+}

--- a/rate_shield/fallback/health_monitor.go
+++ b/rate_shield/fallback/health_monitor.go
@@ -1,0 +1,98 @@
+package fallback
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog/log"
+)
+
+// RedisHealthMonitor monitors Redis connection health and manages reconnection
+type RedisHealthMonitor struct {
+	rateLimitClient  *redis.ClusterClient
+	fallbackClient   *FallbackRateLimitClient
+	fallbackSWClient *FallbackSlidingWindowClient
+	retryInterval    time.Duration
+	stopCh           chan struct{}
+}
+
+// NewRedisHealthMonitor creates a new health monitor
+func NewRedisHealthMonitor(
+	rateLimitClient *redis.ClusterClient,
+	fallbackClient *FallbackRateLimitClient,
+	fallbackSWClient *FallbackSlidingWindowClient,
+	retryInterval time.Duration,
+) *RedisHealthMonitor {
+	return &RedisHealthMonitor{
+		rateLimitClient:  rateLimitClient,
+		fallbackClient:   fallbackClient,
+		fallbackSWClient: fallbackSWClient,
+		retryInterval:    retryInterval,
+		stopCh:           make(chan struct{}),
+	}
+}
+
+// Start begins monitoring Redis health
+func (h *RedisHealthMonitor) Start() {
+	log.Info().Msgf("Starting Redis health monitor (retry interval: %s)", h.retryInterval)
+	go h.monitorHealth()
+}
+
+// Stop stops the health monitor
+func (h *RedisHealthMonitor) Stop() {
+	close(h.stopCh)
+}
+
+// monitorHealth periodically checks Redis connection
+func (h *RedisHealthMonitor) monitorHealth() {
+	ticker := time.NewTicker(h.retryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			h.checkAndRestore()
+		case <-h.stopCh:
+			log.Info().Msg("Redis health monitor stopped")
+			return
+		}
+	}
+}
+
+// checkAndRestore checks if Redis is available and restores connection if needed
+func (h *RedisHealthMonitor) checkAndRestore() {
+	// Only check if we're currently using fallback
+	if h.fallbackClient != nil && !h.fallbackClient.IsRedisAvailable() {
+		if h.pingRedis() {
+			log.Info().Msg("Redis connection restored successfully")
+
+			if h.fallbackClient != nil {
+				h.fallbackClient.RestoreRedis()
+			}
+
+			if h.fallbackSWClient != nil {
+				h.fallbackSWClient.RestoreRedis()
+			}
+		}
+	}
+}
+
+// pingRedis attempts to ping Redis to check availability
+func (h *RedisHealthMonitor) pingRedis() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := h.rateLimitClient.Ping(ctx).Result()
+	if err != nil {
+		log.Debug().Err(err).Msg("Redis ping failed during health check")
+		return false
+	}
+
+	if result == "" || result != "PONG" {
+		log.Debug().Msgf("Redis ping returned unexpected result: %s", result)
+		return false
+	}
+
+	return true
+}

--- a/rate_shield/fallback/memory_store.go
+++ b/rate_shield/fallback/memory_store.go
@@ -1,0 +1,177 @@
+package fallback
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// ExpiringValue holds a value with its expiration time
+type ExpiringValue struct {
+	Value     interface{}
+	ExpiresAt time.Time
+	HasExpiry bool
+}
+
+// InMemoryRateLimitStore provides in-memory storage for rate limiting data
+type InMemoryRateLimitStore struct {
+	data   map[string]*ExpiringValue
+	mutex  sync.RWMutex
+	stopCh chan struct{}
+}
+
+// NewInMemoryRateLimitStore creates a new in-memory store
+func NewInMemoryRateLimitStore() *InMemoryRateLimitStore {
+	store := &InMemoryRateLimitStore{
+		data:   make(map[string]*ExpiringValue),
+		stopCh: make(chan struct{}),
+	}
+
+	// Start background cleanup goroutine
+	go store.cleanupExpiredKeys()
+
+	return store
+}
+
+// JSONSet stores a value as JSON
+func (s *InMemoryRateLimitStore) JSONSet(key string, val interface{}) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	// If the value already exists and has an expiry, preserve it
+	var existingExpiry time.Time
+	var hasExpiry bool
+	if existing, ok := s.data[key]; ok && existing.HasExpiry {
+		existingExpiry = existing.ExpiresAt
+		hasExpiry = true
+	}
+
+	s.data[key] = &ExpiringValue{
+		Value:     val,
+		ExpiresAt: existingExpiry,
+		HasExpiry: hasExpiry,
+	}
+
+	return nil
+}
+
+// JSONGet retrieves a value as JSON string
+func (s *InMemoryRateLimitStore) JSONGet(key string) (string, bool, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	val, found := s.data[key]
+	if !found {
+		return "", false, nil
+	}
+
+	// Check if expired
+	if val.HasExpiry && time.Now().After(val.ExpiresAt) {
+		return "", false, nil
+	}
+
+	// Marshal to JSON
+	jsonBytes, err := json.Marshal(val.Value)
+	if err != nil {
+		log.Error().Err(err).Msg("Error marshaling value to JSON in memory store")
+		return "", false, err
+	}
+
+	return string(jsonBytes), true, nil
+}
+
+// Expire sets an expiration time on a key
+func (s *InMemoryRateLimitStore) Expire(key string, expiration time.Duration) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	val, found := s.data[key]
+	if !found {
+		// Key doesn't exist, nothing to expire
+		return nil
+	}
+
+	val.ExpiresAt = time.Now().Add(expiration)
+	val.HasExpiry = true
+
+	return nil
+}
+
+// Delete removes a key from the store
+func (s *InMemoryRateLimitStore) Delete(key string) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	delete(s.data, key)
+	return nil
+}
+
+// GetKeys returns all keys matching a pattern (simplified - only supports prefix with *)
+func (s *InMemoryRateLimitStore) GetKeys(pattern string) []string {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	var keys []string
+
+	// Simple pattern matching: if pattern ends with *, match prefix
+	if len(pattern) > 0 && pattern[len(pattern)-1] == '*' {
+		prefix := pattern[:len(pattern)-1]
+		for key := range s.data {
+			// Check if expired
+			val := s.data[key]
+			if val.HasExpiry && time.Now().After(val.ExpiresAt) {
+				continue
+			}
+
+			if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+				keys = append(keys, key)
+			}
+		}
+	} else {
+		// Exact match
+		if val, found := s.data[pattern]; found {
+			if !val.HasExpiry || time.Now().Before(val.ExpiresAt) {
+				keys = append(keys, pattern)
+			}
+		}
+	}
+
+	return keys
+}
+
+// cleanupExpiredKeys runs periodically to remove expired keys
+func (s *InMemoryRateLimitStore) cleanupExpiredKeys() {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.mutex.Lock()
+			now := time.Now()
+			for key, val := range s.data {
+				if val.HasExpiry && now.After(val.ExpiresAt) {
+					delete(s.data, key)
+				}
+			}
+			s.mutex.Unlock()
+		case <-s.stopCh:
+			return
+		}
+	}
+}
+
+// Stop stops the cleanup goroutine
+func (s *InMemoryRateLimitStore) Stop() {
+	close(s.stopCh)
+}
+
+// Clear removes all data from the store
+func (s *InMemoryRateLimitStore) Clear() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.data = make(map[string]*ExpiringValue)
+}

--- a/rate_shield/fallback/rules_health_monitor.go
+++ b/rate_shield/fallback/rules_health_monitor.go
@@ -1,0 +1,101 @@
+package fallback
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog/log"
+)
+
+// RulesRefresher interface for components that can refresh cached rules
+type RulesRefresher interface {
+	RefreshCachedRules()
+}
+
+// RulesHealthMonitor monitors Redis rules instance health and manages reconnection
+type RulesHealthMonitor struct {
+	rulesClient    *redis.Client
+	rulesRefresher RulesRefresher
+	retryInterval  time.Duration
+	stopCh         chan struct{}
+	isAvailable    bool
+}
+
+// NewRulesHealthMonitor creates a new rules health monitor
+func NewRulesHealthMonitor(
+	rulesClient *redis.Client,
+	rulesRefresher RulesRefresher,
+	retryInterval time.Duration,
+) *RulesHealthMonitor {
+	return &RulesHealthMonitor{
+		rulesClient:    rulesClient,
+		rulesRefresher: rulesRefresher,
+		retryInterval:  retryInterval,
+		stopCh:         make(chan struct{}),
+		isAvailable:    true, // Start as available
+	}
+}
+
+// Start begins monitoring Redis rules instance health
+func (h *RulesHealthMonitor) Start() {
+	log.Info().Msgf("Starting Rules Redis health monitor (retry interval: %s)", h.retryInterval)
+	go h.monitorHealth()
+}
+
+// Stop stops the health monitor
+func (h *RulesHealthMonitor) Stop() {
+	close(h.stopCh)
+}
+
+// monitorHealth periodically checks Redis rules instance connection
+func (h *RulesHealthMonitor) monitorHealth() {
+	ticker := time.NewTicker(h.retryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			h.checkAndRefresh()
+		case <-h.stopCh:
+			log.Info().Msg("Rules Redis health monitor stopped")
+			return
+		}
+	}
+}
+
+// checkAndRefresh checks if Rules Redis is available and refreshes rules if recovered
+func (h *RulesHealthMonitor) checkAndRefresh() {
+	wasAvailable := h.isAvailable
+	h.isAvailable = h.pingRulesRedis()
+
+	// If it was down and is now up, refresh rules
+	if !wasAvailable && h.isAvailable {
+		log.Info().Msg("Rules Redis connection restored, refreshing cached rules")
+		h.rulesRefresher.RefreshCachedRules()
+	}
+
+	// If it was up and is now down, log warning
+	if wasAvailable && !h.isAvailable {
+		log.Warn().Msg("Rules Redis connection lost, continuing with cached rules")
+	}
+}
+
+// pingRulesRedis attempts to ping Rules Redis to check availability
+func (h *RulesHealthMonitor) pingRulesRedis() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := h.rulesClient.Ping(ctx).Result()
+	if err != nil {
+		log.Debug().Err(err).Msg("Rules Redis ping failed during health check")
+		return false
+	}
+
+	if result == "" || result != "PONG" {
+		log.Debug().Msgf("Rules Redis ping returned unexpected result: %s", result)
+		return false
+	}
+
+	return true
+}

--- a/rate_shield/fallback/sliding_window_adapter.go
+++ b/rate_shield/fallback/sliding_window_adapter.go
@@ -1,0 +1,171 @@
+package fallback
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// SlidingWindowEntry represents a timestamp entry in the sliding window
+type SlidingWindowEntry struct {
+	Timestamp int64
+	ExpiresAt time.Time
+}
+
+// InMemorySlidingWindowStore provides sorted set-like operations for sliding windows
+type InMemorySlidingWindowStore struct {
+	windows map[string][]SlidingWindowEntry
+	mutex   sync.RWMutex
+	stopCh  chan struct{}
+}
+
+// NewInMemorySlidingWindowStore creates a new sliding window store
+func NewInMemorySlidingWindowStore() *InMemorySlidingWindowStore {
+	store := &InMemorySlidingWindowStore{
+		windows: make(map[string][]SlidingWindowEntry),
+		stopCh:  make(chan struct{}),
+	}
+
+	// Start background cleanup
+	go store.cleanupExpiredWindows()
+
+	return store
+}
+
+// ZRemRangeByScore removes entries with scores between min and max (inclusive)
+func (s *InMemorySlidingWindowStore) ZRemRangeByScore(ctx context.Context, key, min, max string) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	entries, found := s.windows[key]
+	if !found {
+		return nil
+	}
+
+	minScore, err := strconv.ParseInt(min, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	maxScore, err := strconv.ParseInt(max, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	// Filter out entries in the range
+	filtered := make([]SlidingWindowEntry, 0)
+	for _, entry := range entries {
+		if entry.Timestamp < minScore || entry.Timestamp > maxScore {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	s.windows[key] = filtered
+	return nil
+}
+
+// ZCount counts entries with scores between min and max (inclusive)
+func (s *InMemorySlidingWindowStore) ZCount(ctx context.Context, key, min, max string) (int64, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	entries, found := s.windows[key]
+	if !found {
+		return 0, nil
+	}
+
+	minScore, err := strconv.ParseInt(min, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	maxScore, err := strconv.ParseInt(max, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	count := int64(0)
+	for _, entry := range entries {
+		if entry.Timestamp >= minScore && entry.Timestamp <= maxScore {
+			count++
+		}
+	}
+
+	return count, nil
+}
+
+// ZAdd adds an entry with the given score
+func (s *InMemorySlidingWindowStore) ZAdd(ctx context.Context, key string, timestamp int64) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	entry := SlidingWindowEntry{
+		Timestamp: timestamp,
+		ExpiresAt: time.Time{}, // Will be set by Expire
+	}
+
+	s.windows[key] = append(s.windows[key], entry)
+
+	// Keep sorted by timestamp for efficiency
+	sort.Slice(s.windows[key], func(i, j int) bool {
+		return s.windows[key][i].Timestamp < s.windows[key][j].Timestamp
+	})
+
+	return nil
+}
+
+// Expire sets expiration time for all entries in a key
+func (s *InMemorySlidingWindowStore) Expire(ctx context.Context, key string, expiration time.Duration) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	entries, found := s.windows[key]
+	if !found {
+		return nil
+	}
+
+	expiresAt := time.Now().Add(expiration)
+	for i := range entries {
+		entries[i].ExpiresAt = expiresAt
+	}
+
+	return nil
+}
+
+// cleanupExpiredWindows runs periodically to remove expired windows
+func (s *InMemorySlidingWindowStore) cleanupExpiredWindows() {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.mutex.Lock()
+			now := time.Now()
+			for key, entries := range s.windows {
+				// Remove if all entries are expired (check first entry since they all have same expiry)
+				if len(entries) > 0 && !entries[0].ExpiresAt.IsZero() && now.After(entries[0].ExpiresAt) {
+					delete(s.windows, key)
+				}
+			}
+			s.mutex.Unlock()
+		case <-s.stopCh:
+			return
+		}
+	}
+}
+
+// Stop stops the cleanup goroutine
+func (s *InMemorySlidingWindowStore) Stop() {
+	close(s.stopCh)
+}
+
+// Clear removes all data
+func (s *InMemorySlidingWindowStore) Clear() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.windows = make(map[string][]SlidingWindowEntry)
+}

--- a/rate_shield/limiter/fixed_window_counter_test.go
+++ b/rate_shield/limiter/fixed_window_counter_test.go
@@ -66,11 +66,13 @@ func TestProcessRequest(t *testing.T) {
 		mockRedis.ExpectedCalls = nil
 		mockRedis.Calls = nil
 
+		now := time.Now().Unix()
 		fixedWindow := &models.FixedWindowCounter{
 			MaxRequests:    10,
 			CurrRequests:   5,
 			Window:         60,
-			LastAccessTime: time.Now().Unix() - 30,
+			CreatedAt:      now - 30,
+			LastAccessTime: now - 30,
 		}
 
 		windowStr, err := json.Marshal(fixedWindow)
@@ -96,11 +98,13 @@ func TestProcessRequest(t *testing.T) {
 		mockRedis.ExpectedCalls = nil
 		mockRedis.Calls = nil
 
+		now := time.Now().Unix()
 		fixedWindow := &models.FixedWindowCounter{
 			MaxRequests:    10,
 			CurrRequests:   10,
 			Window:         60,
-			LastAccessTime: time.Now().Unix() - 30,
+			CreatedAt:      now - 30,
+			LastAccessTime: now - 30,
 		}
 
 		windowStr, err := json.Marshal(fixedWindow)
@@ -125,17 +129,20 @@ func TestProcessRequest(t *testing.T) {
 		mockRedis.ExpectedCalls = nil
 		mockRedis.Calls = nil
 
+		now := time.Now().Unix()
 		fixedWindow := &models.FixedWindowCounter{
 			MaxRequests:    10,
 			CurrRequests:   10,
 			Window:         10,
-			LastAccessTime: time.Now().Unix() - 30,
+			CreatedAt:      now - 30,
+			LastAccessTime: now - 30,
 		}
 
 		windowStr, err := json.Marshal(fixedWindow)
 		assert.NoError(t, err)
 
 		mockRedis.On("JSONGet", mock.Anything).Return(string(windowStr), true, nil)
+		mockRedis.On("JSONSet", mock.Anything, mock.Anything).Return(nil)
 
 		rule := &models.Rule{
 			FixedWindowCounterRule: &models.FixedWindowCounterRule{
@@ -143,7 +150,7 @@ func TestProcessRequest(t *testing.T) {
 				Window:      60,
 			},
 		}
-		mockRedis.On("JSONSet", mock.Anything, mock.Anything).Return(nil)
+
 		response := service.processRequest("192.168.1.4", "/test", rule)
 
 		assert.Equal(t, 200, response.HTTPStatusCode)

--- a/rate_shield/limiter/limiter.go
+++ b/rate_shield/limiter/limiter.go
@@ -128,11 +128,16 @@ func (l *Limiter) listenToRulesUpdate() {
 		data := <-updatesChannel
 
 		if data == "UpdateRules" {
-			l.rulesMutex.Lock()
-			l.cachedRules = l.redisRuleSvc.CacheRulesLocally()
-			l.rulesMutex.Unlock()
-
-			log.Info().Msg("Rules Updated Successfully")
+			l.RefreshCachedRules()
 		}
 	}
+}
+
+// RefreshCachedRules refreshes the locally cached rules from Redis
+func (l *Limiter) RefreshCachedRules() {
+	l.rulesMutex.Lock()
+	defer l.rulesMutex.Unlock()
+
+	l.cachedRules = l.redisRuleSvc.CacheRulesLocally()
+	log.Info().Msgf("Rules cache refreshed - Total Rules: %d", len(*l.cachedRules))
 }

--- a/rate_shield/main.go
+++ b/rate_shield/main.go
@@ -8,9 +8,11 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/x-sushant-x/RateShield/api"
+	"github.com/x-sushant-x/RateShield/fallback"
 	"github.com/x-sushant-x/RateShield/limiter"
 	redisClient "github.com/x-sushant-x/RateShield/redis"
 	"github.com/x-sushant-x/RateShield/service"
+	"github.com/x-sushant-x/RateShield/utils"
 )
 
 var (
@@ -27,10 +29,20 @@ func init() {
 }
 
 func main() {
+	fallbackEnabled := utils.GetRedisFallbackEnabled()
+
+	if fallbackEnabled {
+		log.Info().Msg("Redis fallback is ENABLED - will use in-memory storage if Redis is unavailable")
+	} else {
+		log.Info().Msg("Redis fallback is DISABLED - application will fail if Redis is unavailable")
+	}
 
 	redisRulesClient, err := redisClient.NewRulesClient()
 	if err != nil {
-		log.Fatal().Err(err)
+		if !fallbackEnabled {
+			log.Fatal().Err(err)
+		}
+		log.Warn().Msg("Redis rules client unavailable, continuing with fallback")
 	}
 
 	slackSvc := service.NewSlackService(slackToken, slackChannelID)
@@ -39,16 +51,79 @@ func main() {
 
 	redisRateLimiter, clusterClient, err := redisClient.NewRedisRateLimitClient()
 	if err != nil {
-		log.Fatal().Err(err)
+		if !fallbackEnabled {
+			log.Fatal().Err(err)
+		}
+		log.Warn().Msg("Redis rate limit client unavailable, initializing in-memory fallback")
+
+		// Initialize in-memory stores
+		memoryStore := fallback.NewInMemoryRateLimitStore()
+		memorySWStore := fallback.NewInMemorySlidingWindowStore()
+
+		// Create fallback clients with nil Redis clients
+		rateLimitClient := fallback.NewFallbackRateLimitClient(nil, memoryStore)
+		slidingWindowClient := fallback.NewFallbackSlidingWindowClient(nil, memorySWStore)
+
+		// Mark as unavailable from the start
+		rateLimitClient.RestoreRedis() // This won't actually restore, just sets the state
+
+		// Create services with fallback clients
+		tokenBucketSvc := limiter.NewTokenBucketService(rateLimitClient, errorNotificationSvc)
+		fixedWindowSvc := limiter.NewFixedWindowService(rateLimitClient)
+
+		redisRulesSvc := service.NewRedisRulesService(redisRulesClient)
+
+		slidingWindowSvc := limiter.NewSlidingWindowService(slidingWindowClient)
+
+		limiter := limiter.NewRateLimiterService(&tokenBucketSvc, &fixedWindowSvc, &slidingWindowSvc, redisRulesSvc)
+		limiter.StartRateLimiter()
+
+		// Start health monitor to check for Redis recovery
+		if clusterClient != nil {
+			retryInterval := utils.GetRedisRetryInterval()
+			healthMonitor := fallback.NewRedisHealthMonitor(clusterClient, rateLimitClient, slidingWindowClient, retryInterval)
+			healthMonitor.Start()
+		}
+
+		server := api.NewServer(&limiter)
+		log.Fatal().Err(server.StartServer())
+		return
 	}
 
+	// Normal flow when Redis is available
 	tokenBucketSvc := limiter.NewTokenBucketService(redisRateLimiter, errorNotificationSvc)
-
 	fixedWindowSvc := limiter.NewFixedWindowService(redisRateLimiter)
-
 	redisRulesSvc := service.NewRedisRulesService(redisRulesClient)
 
-	slidingWindowSvc := limiter.NewSlidingWindowService(clusterClient)
+	// Create sliding window client with interface
+	slidingWindowClient := redisClient.NewSlidingWindowClient(clusterClient)
+
+	// If fallback is enabled, wrap with fallback client
+	var finalSWClient redisClient.SlidingWindowClient = slidingWindowClient
+	var finalRateLimitClient redisClient.RedisRateLimiterClient = redisRateLimiter
+
+	if fallbackEnabled {
+		log.Info().Msg("Wrapping Redis clients with fallback support")
+		memoryStore := fallback.NewInMemoryRateLimitStore()
+		memorySWStore := fallback.NewInMemorySlidingWindowStore()
+
+		rateLimitFallback := fallback.NewFallbackRateLimitClient(redisRateLimiter, memoryStore)
+		slidingWindowFallback := fallback.NewFallbackSlidingWindowClient(slidingWindowClient, memorySWStore)
+
+		finalRateLimitClient = rateLimitFallback
+		finalSWClient = slidingWindowFallback
+
+		// Start health monitor
+		retryInterval := utils.GetRedisRetryInterval()
+		healthMonitor := fallback.NewRedisHealthMonitor(clusterClient, rateLimitFallback, slidingWindowFallback, retryInterval)
+		healthMonitor.Start()
+
+		// Recreate services with fallback clients
+		tokenBucketSvc = limiter.NewTokenBucketService(finalRateLimitClient, errorNotificationSvc)
+		fixedWindowSvc = limiter.NewFixedWindowService(finalRateLimitClient)
+	}
+
+	slidingWindowSvc := limiter.NewSlidingWindowService(finalSWClient)
 
 	limiter := limiter.NewRateLimiterService(&tokenBucketSvc, &fixedWindowSvc, &slidingWindowSvc, redisRulesSvc)
 	limiter.StartRateLimiter()

--- a/rate_shield/redis/interfaces.go
+++ b/rate_shield/redis/interfaces.go
@@ -1,6 +1,7 @@
 package redisClient
 
 import (
+	"context"
 	"time"
 
 	"github.com/x-sushant-x/RateShield/models"
@@ -20,4 +21,12 @@ type RedisRateLimiterClient interface {
 	JSONGet(key string) (string, bool, error)
 	Expire(key string, expireTime time.Duration) error
 	Delete(key string) error
+}
+
+// SlidingWindowClient defines operations needed for sliding window rate limiting
+type SlidingWindowClient interface {
+	ZRemRangeByScore(ctx context.Context, key, min, max string) error
+	ZCount(ctx context.Context, key, min, max string) (int64, error)
+	ZAdd(ctx context.Context, key string, timestamp int64) error
+	Expire(ctx context.Context, key string, expiration time.Duration) error
 }

--- a/rate_shield/redis/sliding_window_adapter.go
+++ b/rate_shield/redis/sliding_window_adapter.go
@@ -1,0 +1,80 @@
+package redisClient
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisSlidingWindowClient wraps redis.ClusterClient to implement SlidingWindowClient interface
+type RedisSlidingWindowClient struct {
+	client *redis.ClusterClient
+}
+
+// NewRedisSlidingWindowClient creates a new Redis sliding window client
+func NewRedisSlidingWindowClient(client *redis.ClusterClient) *RedisSlidingWindowClient {
+	return &RedisSlidingWindowClient{
+		client: client,
+	}
+}
+
+// ZRemRangeByScore removes entries with scores between min and max
+func (r *RedisSlidingWindowClient) ZRemRangeByScore(ctx context.Context, key, min, max string) error {
+	return r.client.ZRemRangeByScore(ctx, key, min, max).Err()
+}
+
+// ZCount counts entries with scores between min and max
+func (r *RedisSlidingWindowClient) ZCount(ctx context.Context, key, min, max string) (int64, error) {
+	return r.client.ZCount(ctx, key, min, max).Result()
+}
+
+// ZAdd adds an entry with the given score
+func (r *RedisSlidingWindowClient) ZAdd(ctx context.Context, key string, timestamp int64) error {
+	return r.client.ZAdd(ctx, key, redis.Z{
+		Member: timestamp,
+		Score:  float64(timestamp),
+	}).Err()
+}
+
+// Expire sets expiration time on a key
+func (r *RedisSlidingWindowClient) Expire(ctx context.Context, key string, expiration time.Duration) error {
+	return r.client.Expire(ctx, key, expiration).Err()
+}
+
+// ExecutePipeline executes a pipeline of commands for sliding window operations
+func (r *RedisSlidingWindowClient) ExecutePipeline(ctx context.Context, key string, now int64, windowSize time.Duration) (int64, error) {
+	then := fmt.Sprintf("%d", now-int64(windowSize.Seconds()))
+
+	pipe := r.client.TxPipeline()
+	pipe.ZRemRangeByScore(ctx, key, "0", then)
+	countCmd := pipe.ZCount(ctx, key, then, fmt.Sprintf("%d", now))
+
+	_, err := pipe.Exec(ctx)
+	if err != nil {
+		return -1, err
+	}
+
+	count, err := countCmd.Result()
+	if err != nil {
+		return -1, err
+	}
+
+	return count, nil
+}
+
+// UpdateWindow adds a timestamp and sets expiration in a pipeline
+func (r *RedisSlidingWindowClient) UpdateWindow(ctx context.Context, key string, now int64, windowSize time.Duration) error {
+	pipe := r.client.TxPipeline()
+
+	pipe.ZAdd(ctx, key, redis.Z{
+		Member: now,
+		Score:  float64(now),
+	})
+
+	pipe.Expire(ctx, key, windowSize)
+
+	_, err := pipe.Exec(ctx)
+	return err
+}

--- a/rate_shield/service/rules.go
+++ b/rate_shield/service/rules.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -36,16 +35,10 @@ func NewRedisRulesService(client redisClient.RedisRuleClient) RulesServiceRedis 
 }
 
 func (s RulesServiceRedis) GetRule(key string) (*models.Rule, bool, error) {
-	if s.redisClient == nil {
-		return nil, false, nil
-	}
 	return s.redisClient.GetRule(key)
 }
 
 func (s RulesServiceRedis) GetAllRules() ([]models.Rule, error) {
-	if s.redisClient == nil {
-		return []models.Rule{}, nil
-	}
 	keys, _, err := s.redisClient.GetAllRuleKeys()
 	if err != nil {
 		log.Err(err).Msg("unable to get all rule keys from redis")
@@ -89,9 +82,6 @@ func (s RulesServiceRedis) SearchRule(searchText string) ([]models.Rule, error) 
 }
 
 func (s RulesServiceRedis) CreateOrUpdateRule(rule models.Rule) error {
-	if s.redisClient == nil {
-		return fmt.Errorf("redis client unavailable - cannot create or update rules in fallback mode")
-	}
 	err := s.redisClient.SetRule(rule.APIEndpoint, rule)
 	if err != nil {
 		log.Err(err).Msg("unable to create or update rule")
@@ -102,9 +92,6 @@ func (s RulesServiceRedis) CreateOrUpdateRule(rule models.Rule) error {
 }
 
 func (s RulesServiceRedis) DeleteRule(endpoint string) error {
-	if s.redisClient == nil {
-		return fmt.Errorf("redis client unavailable - cannot delete rules in fallback mode")
-	}
 	err := s.redisClient.DeleteRule(endpoint)
 	if err != nil {
 		log.Err(err).Msg("unable to create or update rule")
@@ -131,10 +118,6 @@ func (s RulesServiceRedis) CacheRulesLocally() *map[string]*models.Rule {
 }
 
 func (s RulesServiceRedis) ListenToRulesUpdate(updatesChannel chan string) {
-	if s.redisClient == nil {
-		log.Warn().Msg("Redis client unavailable - cannot listen to rule updates in fallback mode")
-		return
-	}
 	s.redisClient.ListenToRulesUpdate(updatesChannel)
 }
 

--- a/rate_shield/utils/env.go
+++ b/rate_shield/utils/env.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -39,6 +41,38 @@ func GetRedisClusterURLs() []string {
 func GetRedisClusterPassword() string {
 	password := os.Getenv("REDIS_CLUSTER_PASSWORD")
 	return password
+}
+
+// GetRedisFallbackEnabled returns whether in-memory fallback is enabled when Redis is unavailable
+func GetRedisFallbackEnabled() bool {
+	fallbackEnabled := os.Getenv("ENABLE_REDIS_FALLBACK")
+	if len(fallbackEnabled) == 0 {
+		return false
+	}
+
+	enabled, err := strconv.ParseBool(fallbackEnabled)
+	if err != nil {
+		log.Warn().Msgf("Invalid ENABLE_REDIS_FALLBACK value: %s, defaulting to false", fallbackEnabled)
+		return false
+	}
+
+	return enabled
+}
+
+// GetRedisRetryInterval returns the interval for retrying Redis connection when using fallback
+func GetRedisRetryInterval() time.Duration {
+	retryInterval := os.Getenv("REDIS_RETRY_INTERVAL")
+	if len(retryInterval) == 0 {
+		return 30 * time.Second // default 30 seconds
+	}
+
+	duration, err := time.ParseDuration(retryInterval)
+	if err != nil {
+		log.Warn().Msgf("Invalid REDIS_RETRY_INTERVAL value: %s, defaulting to 30s", retryInterval)
+		return 30 * time.Second
+	}
+
+	return duration
 }
 
 func checkEmptyENV(Var string, message string) {


### PR DESCRIPTION
  Add optional in-memory fallback mechanism that activates when Redis
  becomes unavailable, ensuring Rate Shield continues to function during
  Redis outages.

  Features:
  - Automatic failover to in-memory storage when Redis fails
  - Background health monitor with configurable retry interval
  - Auto-recovery when Redis becomes available again
  - Support for all rate limiting algorithms (Token Bucket, Fixed Window, Sliding Window)

  Implementation:
  - Created fallback package with memory store and client wrappers
  - Added SlidingWindowClient interface for abstraction
  - Updated Redis client for non-fatal error handling when fallback enabled
  - Integrated health monitoring with periodic Redis ping checks

  Configuration:
  - ENABLE_REDIS_FALLBACK: Enable/disable fallback (default: false)
  - REDIS_RETRY_INTERVAL: Retry interval for health checks (default: 30s)

  Documentation:
  - Added REDIS_FALLBACK.md with complete feature documentation
  - Updated README.md with fallback feature in key features
  - Updated SETUP.md with configuration and usage examples
  - Added fallback section to usage documentation

  Limitations:
  - In-memory data is per-instance (not distributed)
  - Data lost on restart (non-persistent)
  - Best for development, testing, or temporary resilience
  - Not recommended for production multi-instance deployments

  Resolves #53