### PR TITLE
Feature/redis in memory fallback 53

### DIFF
--- a/rate_shield/api/server.go
+++ b/rate_shield/api/server.go
@@ -65,7 +65,7 @@ func (s Server) setupCORS(h http.Handler) http.Handler {
 }
 
 func (s Server) rulesRoutes(mux *http.ServeMux) {
-	redisRuleClient, err := redisClient.NewRulesClient()
+	redisRuleClient, _, err := redisClient.NewRulesClient()
 	if err != nil {
 		log.Err(err).Msg("unable to setup new redis rules client")
 		log.Fatal()

--- a/rate_shield/fallback/rules_health_monitor.go
+++ b/rate_shield/fallback/rules_health_monitor.go
@@ -1,0 +1,101 @@
+package fallback
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog/log"
+)
+
+// RulesRefresher interface for components that can refresh cached rules
+type RulesRefresher interface {
+	RefreshCachedRules()
+}
+
+// RulesHealthMonitor monitors Redis rules instance health and manages reconnection
+type RulesHealthMonitor struct {
+	rulesClient    *redis.Client
+	rulesRefresher RulesRefresher
+	retryInterval  time.Duration
+	stopCh         chan struct{}
+	isAvailable    bool
+}
+
+// NewRulesHealthMonitor creates a new rules health monitor
+func NewRulesHealthMonitor(
+	rulesClient *redis.Client,
+	rulesRefresher RulesRefresher,
+	retryInterval time.Duration,
+) *RulesHealthMonitor {
+	return &RulesHealthMonitor{
+		rulesClient:    rulesClient,
+		rulesRefresher: rulesRefresher,
+		retryInterval:  retryInterval,
+		stopCh:         make(chan struct{}),
+		isAvailable:    true, // Start as available
+	}
+}
+
+// Start begins monitoring Redis rules instance health
+func (h *RulesHealthMonitor) Start() {
+	log.Info().Msgf("Starting Rules Redis health monitor (retry interval: %s)", h.retryInterval)
+	go h.monitorHealth()
+}
+
+// Stop stops the health monitor
+func (h *RulesHealthMonitor) Stop() {
+	close(h.stopCh)
+}
+
+// monitorHealth periodically checks Redis rules instance connection
+func (h *RulesHealthMonitor) monitorHealth() {
+	ticker := time.NewTicker(h.retryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			h.checkAndRefresh()
+		case <-h.stopCh:
+			log.Info().Msg("Rules Redis health monitor stopped")
+			return
+		}
+	}
+}
+
+// checkAndRefresh checks if Rules Redis is available and refreshes rules if recovered
+func (h *RulesHealthMonitor) checkAndRefresh() {
+	wasAvailable := h.isAvailable
+	h.isAvailable = h.pingRulesRedis()
+
+	// If it was down and is now up, refresh rules
+	if !wasAvailable && h.isAvailable {
+		log.Info().Msg("Rules Redis connection restored, refreshing cached rules")
+		h.rulesRefresher.RefreshCachedRules()
+	}
+
+	// If it was up and is now down, log warning
+	if wasAvailable && !h.isAvailable {
+		log.Warn().Msg("Rules Redis connection lost, continuing with cached rules")
+	}
+}
+
+// pingRulesRedis attempts to ping Rules Redis to check availability
+func (h *RulesHealthMonitor) pingRulesRedis() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := h.rulesClient.Ping(ctx).Result()
+	if err != nil {
+		log.Debug().Err(err).Msg("Rules Redis ping failed during health check")
+		return false
+	}
+
+	if result == "" || result != "PONG" {
+		log.Debug().Msgf("Rules Redis ping returned unexpected result: %s", result)
+		return false
+	}
+
+	return true
+}

--- a/rate_shield/limiter/fixed_window_counter_test.go
+++ b/rate_shield/limiter/fixed_window_counter_test.go
@@ -66,11 +66,13 @@ func TestProcessRequest(t *testing.T) {
 		mockRedis.ExpectedCalls = nil
 		mockRedis.Calls = nil
 
+		now := time.Now().Unix()
 		fixedWindow := &models.FixedWindowCounter{
 			MaxRequests:    10,
 			CurrRequests:   5,
 			Window:         60,
-			LastAccessTime: time.Now().Unix() - 30,
+			CreatedAt:      now - 30,
+			LastAccessTime: now - 30,
 		}
 
 		windowStr, err := json.Marshal(fixedWindow)
@@ -96,11 +98,13 @@ func TestProcessRequest(t *testing.T) {
 		mockRedis.ExpectedCalls = nil
 		mockRedis.Calls = nil
 
+		now := time.Now().Unix()
 		fixedWindow := &models.FixedWindowCounter{
 			MaxRequests:    10,
 			CurrRequests:   10,
 			Window:         60,
-			LastAccessTime: time.Now().Unix() - 30,
+			CreatedAt:      now - 30,
+			LastAccessTime: now - 30,
 		}
 
 		windowStr, err := json.Marshal(fixedWindow)
@@ -125,17 +129,20 @@ func TestProcessRequest(t *testing.T) {
 		mockRedis.ExpectedCalls = nil
 		mockRedis.Calls = nil
 
+		now := time.Now().Unix()
 		fixedWindow := &models.FixedWindowCounter{
 			MaxRequests:    10,
 			CurrRequests:   10,
 			Window:         10,
-			LastAccessTime: time.Now().Unix() - 30,
+			CreatedAt:      now - 30,
+			LastAccessTime: now - 30,
 		}
 
 		windowStr, err := json.Marshal(fixedWindow)
 		assert.NoError(t, err)
 
 		mockRedis.On("JSONGet", mock.Anything).Return(string(windowStr), true, nil)
+		mockRedis.On("JSONSet", mock.Anything, mock.Anything).Return(nil)
 
 		rule := &models.Rule{
 			FixedWindowCounterRule: &models.FixedWindowCounterRule{
@@ -143,7 +150,7 @@ func TestProcessRequest(t *testing.T) {
 				Window:      60,
 			},
 		}
-		mockRedis.On("JSONSet", mock.Anything, mock.Anything).Return(nil)
+
 		response := service.processRequest("192.168.1.4", "/test", rule)
 
 		assert.Equal(t, 200, response.HTTPStatusCode)

--- a/rate_shield/limiter/limiter.go
+++ b/rate_shield/limiter/limiter.go
@@ -128,11 +128,16 @@ func (l *Limiter) listenToRulesUpdate() {
 		data := <-updatesChannel
 
 		if data == "UpdateRules" {
-			l.rulesMutex.Lock()
-			l.cachedRules = l.redisRuleSvc.CacheRulesLocally()
-			l.rulesMutex.Unlock()
-
-			log.Info().Msg("Rules Updated Successfully")
+			l.RefreshCachedRules()
 		}
 	}
+}
+
+// RefreshCachedRules refreshes the locally cached rules from Redis
+func (l *Limiter) RefreshCachedRules() {
+	l.rulesMutex.Lock()
+	defer l.rulesMutex.Unlock()
+
+	l.cachedRules = l.redisRuleSvc.CacheRulesLocally()
+	log.Info().Msgf("Rules cache refreshed - Total Rules: %d", len(*l.cachedRules))
 }

--- a/rate_shield/service/rules.go
+++ b/rate_shield/service/rules.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -36,16 +35,10 @@ func NewRedisRulesService(client redisClient.RedisRuleClient) RulesServiceRedis 
 }
 
 func (s RulesServiceRedis) GetRule(key string) (*models.Rule, bool, error) {
-	if s.redisClient == nil {
-		return nil, false, nil
-	}
 	return s.redisClient.GetRule(key)
 }
 
 func (s RulesServiceRedis) GetAllRules() ([]models.Rule, error) {
-	if s.redisClient == nil {
-		return []models.Rule{}, nil
-	}
 	keys, _, err := s.redisClient.GetAllRuleKeys()
 	if err != nil {
 		log.Err(err).Msg("unable to get all rule keys from redis")
@@ -89,9 +82,6 @@ func (s RulesServiceRedis) SearchRule(searchText string) ([]models.Rule, error) 
 }
 
 func (s RulesServiceRedis) CreateOrUpdateRule(rule models.Rule) error {
-	if s.redisClient == nil {
-		return fmt.Errorf("redis client unavailable - cannot create or update rules in fallback mode")
-	}
 	err := s.redisClient.SetRule(rule.APIEndpoint, rule)
 	if err != nil {
 		log.Err(err).Msg("unable to create or update rule")
@@ -102,9 +92,6 @@ func (s RulesServiceRedis) CreateOrUpdateRule(rule models.Rule) error {
 }
 
 func (s RulesServiceRedis) DeleteRule(endpoint string) error {
-	if s.redisClient == nil {
-		return fmt.Errorf("redis client unavailable - cannot delete rules in fallback mode")
-	}
 	err := s.redisClient.DeleteRule(endpoint)
 	if err != nil {
 		log.Err(err).Msg("unable to create or update rule")
@@ -131,10 +118,6 @@ func (s RulesServiceRedis) CacheRulesLocally() *map[string]*models.Rule {
 }
 
 func (s RulesServiceRedis) ListenToRulesUpdate(updatesChannel chan string) {
-	if s.redisClient == nil {
-		log.Warn().Msg("Redis client unavailable - cannot listen to rule updates in fallback mode")
-		return
-	}
 	s.redisClient.ListenToRulesUpdate(updatesChannel)
 }
 


### PR DESCRIPTION
fix: separate Redis instances - rules always required, cluster supports fallback (#53)

  Split fallback behavior between two Redis instances:
  - Rules Instance: ALWAYS required at startup (no fallback)
  - Rate Limit Cluster: Supports in-memory fallback (optional)

  This prevents empty rules map scenario where all requests would bypass
  rate limiting if rules instance was unavailable.

  Changes:
  - Rules instance must be available at startup (app exits otherwise)
  - Rules cached in-memory; auto-refresh when instance recovers
  - Rate limit cluster fallback remains unchanged
  - Added rules health monitor for runtime recovery
  - Updated all documentation to clarify architecture