### PR TITLE
refactor: optimize time calls and improve error handling

### DIFF
--- a/rate_shield/limiter/fixed_window_counter.go
+++ b/rate_shield/limiter/fixed_window_counter.go
@@ -106,14 +106,15 @@ func (fw *FixedWindowService) getFixedWindowFromRedis(key string) (*models.Fixed
 }
 
 func (fw *FixedWindowService) makeFixedWindowCounter(ip, endpoint string, rule *models.Rule) models.FixedWindowCounter {
+	now := time.Now().Unix()
 	return models.FixedWindowCounter{
 		Endpoint:       endpoint,
 		ClientIP:       ip,
-		CreatedAt:      time.Now().Unix(),
+		CreatedAt:      now,
 		MaxRequests:    rule.FixedWindowCounterRule.MaxRequests,
 		CurrRequests:   1,
 		Window:         rule.FixedWindowCounterRule.Window,
-		LastAccessTime: time.Now().Unix(),
+		LastAccessTime: now,
 	}
 }
 

--- a/rate_shield/limiter/limiter.go
+++ b/rate_shield/limiter/limiter.go
@@ -57,10 +57,6 @@ func (l *Limiter) CheckLimit(ip, endpoint string) *models.RateLimitResponse {
 		}
 	}
 
-	if !found {
-		return utils.BuildRateLimitSuccessResponse(0, 0)
-	}
-
 	return utils.BuildRateLimitSuccessResponse(0, 0)
 }
 

--- a/rate_shield/service/slack_messaging.go
+++ b/rate_shield/service/slack_messaging.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 
 	"github.com/rs/zerolog/log"
@@ -68,6 +69,7 @@ func (s *SlackService) sendRequestToSlackAPI(req *http.Request) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("received non-OK response from Slack: %s", resp.Status)
 		log.Err(err).Msgf("received non-OK response from Slack: %s", resp.Status)
 		return err
 	}


### PR DESCRIPTION
- Use single time.Now() call in fixed window counter
- Remove unreachable code in limiter
- Fix error creation in Slack messaging